### PR TITLE
Handle deleted events when pulling event details

### DIFF
--- a/app/jobs/pull_event_details_job.rb
+++ b/app/jobs/pull_event_details_job.rb
@@ -15,6 +15,14 @@ class PullEventDetailsJob < ApplicationJob
       owner_name: character_calendar_event.owner_name,
       owner_uid: character_calendar_event.owner_id,
     )
+  rescue EveOnline::Exceptions::ResourceNotFound => e
+    # Pass. Log the error to keep an eye on such situations
+    report_error(e)
+    # Drop the event, it has been deleted
+    event.destroy!
+  rescue ActiveRecord::RecordNotFound => e
+    # Pass and drop the job
+    report_error(e)
   end
 
   private


### PR DESCRIPTION
An attempt to pull the details for a non-existing event, results with an error `EveOnline::Exceptions::ResourceNotFound` i.e the event has been deleted.

The job will now rescue `EveOnline::Exceptions::ResourceNotFound` errors and delete the event from the database.

The event is deleted because:

* It keeps it simple when it comes to serving up-to-date event feeds
* We're not in the business of collecting data

There is also a possibility that the character does not exist. However, in this scenario, errors will be reported by other character-related operations so we'll keep things simple and not handle this case.