### PR TITLE
Delete removed upcoming events

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -5,9 +5,9 @@ class Event < ApplicationRecord
   validates :title, presence: true
   validates :uid, presence: true
 
-  def self.upcoming_for(character)
+  def self.upcoming_for(character, since: Date.current)
     where(character: character).
-      where("starts_at >= ?", Date.current).
+      where("starts_at >= ?", since).
       order(starts_at: :asc)
   end
 

--- a/spec/jobs/pull_upcoming_events_job_spec.rb
+++ b/spec/jobs/pull_upcoming_events_job_spec.rb
@@ -23,6 +23,26 @@ describe PullUpcomingEventsJob, type: :job do
       to("new")
   end
 
+  it "deletes removed upcoming events" do
+    create(:event, character: character, starts_at: 1.second.from_now)
+
+    stub_character_calendar(events: [])
+
+    expect { PullUpcomingEventsJob.perform_now(character.id) }.
+      to change { Event.count }.
+      from(1).
+      to(0)
+  end
+
+  it "does not delete past events" do
+    create(:event, character: character, starts_at: 1.second.ago)
+
+    stub_character_calendar(events: [])
+
+    expect { PullUpcomingEventsJob.perform_now(character.id) }.
+      not_to(change { Event.count })
+  end
+
   def character
     @character ||= create(:character)
   end


### PR DESCRIPTION
Some upcoming events may still be shown to players, despite their owner deleting them. The `PullUpcomingEventsJob` only saves new or updates existing events. However, it does not delete removed events.

Upcoming events present in our database but not returned by ESI will now also be removed from the database.

Closes #157