### PR TITLE
Enable asynchronous Sentry notifications

### DIFF
--- a/app/jobs/sentry_job.rb
+++ b/app/jobs/sentry_job.rb
@@ -1,0 +1,7 @@
+class SentryJob < ApplicationJob
+  queue_as :default
+
+  def perform(event)
+    Raven.send_event(event)
+  end
+end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,4 +1,8 @@
 Raven.configure do |config|
   # Set by bin/deploy
   config.release = ENV.fetch("CURRENT_SHA", "unknown").split(" ").first
+
+  config.async = lambda { |event|
+    SentryJob.perform_later(event)
+  }
 end

--- a/spec/jobs/sentry_job_spec.rb
+++ b/spec/jobs/sentry_job_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+describe SentryJob, type: :job do
+  it "sends given event to Sentry" do
+    allow(Raven).to receive(:send_event)
+
+    SentryJob.perform_now(ok: false)
+
+    expect(Raven).to have_received(:send_event).with(ok: false)
+  end
+end


### PR DESCRIPTION
When an error or message occurs, the notification is immediately sent to Sentry, synchronously. This means that returning a response to a user may be delayed.

This commit enables asynchronous notifications using a background job for delivering events to Sentry.

Closes #129