### PR TITLE
Extract access token revocation into its own class

### DIFF
--- a/app/controllers/calendars_controller.rb
+++ b/app/controllers/calendars_controller.rb
@@ -13,13 +13,17 @@ class CalendarsController < ApplicationController
     when /time zone/i
       remember_preferred_time_zone(params[:tz])
     else
-      personal_token.try(&:revoke!)
+      revoke_access_token
     end
 
     redirect_to calendar_url
   end
 
   private
+
+  def revoke_access_token
+    AccessTokenRevocation.new(personal_token).call
+  end
 
   def remember_preferred_time_zone(value)
     character_settings.update!(time_zone: value)

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -21,22 +21,6 @@ class AccessToken < ApplicationRecord
       create!(issuer: char, grantee: char)
     end
 
-    def revoke!(access_token)
-      if access_token.invalid? || !access_token.persisted?
-        raise ArgumentError, "Valid and persisted access token expected"
-      end
-
-      transaction do
-        where(
-          issuer: access_token.issuer,
-          grantee: access_token.grantee,
-          revoked_at: nil,
-        ).lock.update_all(revoked_at: Time.current)
-
-        create!(issuer: access_token.issuer, grantee: access_token.grantee)
-      end
-    end
-
     private
 
     def parse_slug(slug)
@@ -54,10 +38,6 @@ class AccessToken < ApplicationRecord
 
   def to_param
     slug
-  end
-
-  def revoke!
-    AccessToken.revoke!(self)
   end
 
   def personal?

--- a/app/models/access_token_revocation.rb
+++ b/app/models/access_token_revocation.rb
@@ -1,0 +1,29 @@
+class AccessTokenRevocation
+  include ActiveModel::Validations
+
+  validates :issuer, presence: true
+  validates :grantee, presence: true
+
+  def initialize(access_token)
+    @issuer = access_token.issuer
+    @grantee = access_token.grantee
+  end
+
+  def call
+    validate!
+
+    AccessToken.transaction do
+      AccessToken.
+        where(issuer: issuer, grantee: grantee, revoked_at: nil).
+        lock.
+        update_all(revoked_at: Time.current)
+
+      AccessToken.create!(issuer: issuer, grantee: grantee)
+    end
+  end
+
+  private
+
+  attr_reader :issuer
+  attr_reader :grantee
+end

--- a/spec/models/access_token_revocation_spec.rb
+++ b/spec/models/access_token_revocation_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+describe AccessTokenRevocation do
+  describe "#call" do
+    it "revokes given access token" do
+      access_token = create(:access_token)
+
+      revocation = AccessTokenRevocation.new(access_token)
+
+      expect { revocation.call }.
+        to change { access_token.reload.revoked? }.
+        from(false).
+        to(true)
+    end
+
+    it "records revocation time" do
+      access_token = create(:access_token)
+
+      revocation = AccessTokenRevocation.new(access_token)
+
+      expect { revocation.call }.
+        to change { access_token.reload.revoked_at }.
+        from(nil)
+    end
+
+    it "creates a new access token" do
+      access_token = create(:access_token)
+
+      expect { AccessTokenRevocation.new(access_token).call }.
+        to change { AccessToken.count }.
+        by(1)
+    end
+
+    it "returns a valid access token" do
+      access_token = create(:access_token)
+
+      result = AccessTokenRevocation.new(access_token).call
+
+      expect(result.issuer).to eq(access_token.issuer)
+      expect(result.grantee).to eq(access_token.grantee)
+      expect(result.revoked?).to eq(false)
+    end
+
+    it "raises an error when issuer is not present" do
+      access_token = build(:access_token, :personal, issuer: nil)
+
+      revocation = AccessTokenRevocation.new(access_token)
+
+      expect { revocation.call }.
+        to raise_error(ActiveModel::ValidationError, /issuer/i)
+    end
+
+    it "raises an error when grantee is not present" do
+      access_token = build(:access_token, :personal, grantee: nil)
+
+      revocation = AccessTokenRevocation.new(access_token)
+
+      expect { revocation.call }.
+        to raise_error(ActiveModel::ValidationError, /grantee/i)
+    end
+  end
+end

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -59,38 +59,6 @@ describe AccessToken, type: :model do
     end
   end
 
-  describe ".revoke!" do
-    it "revokes the given instance" do
-      token = create(:access_token)
-
-      expect { AccessToken.revoke!(token) }.to change { token.reload.revoked? }.
-        from(false).to(true)
-    end
-
-    it "returns a new token" do
-      token = create(:access_token)
-
-      new_token = AccessToken.revoke!(token)
-
-      expect(new_token.issuer).to eq(token.issuer)
-      expect(new_token.grantee).to eq(token.grantee)
-      expect(new_token.revoked?).to eq(false)
-    end
-  end
-
-  describe "#revoke!" do
-    it "is revoked" do
-      token = create(:access_token)
-
-      # Stubbing the SUT?
-      allow(AccessToken).to receive(:revoke!)
-
-      token.revoke!
-
-      expect(AccessToken).to have_received(:revoke!).with(token)
-    end
-  end
-
   describe "#revoked?" do
     it "returns true, when revocation time present" do
       token = build(:access_token, revoked_at: Time.current)


### PR DESCRIPTION
Narrow down the responsibilities of the `AccessToken` model.