### PR TITLE
Pull events for new characters after signin

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,6 @@
 class SessionsController < ApplicationController
+  NEW_SIGNUP_THRESHOLD = 5.seconds.freeze
+
   def create
     reset_session
 
@@ -7,7 +9,10 @@ class SessionsController < ApplicationController
     character = Eve::SignIn.new(auth_hash).call
 
     if character.present?
+      schedule_upcoming_events_pull_if_needed(character)
+
       session[:character_id] = character.id
+
       redirect_to calendar_url
     else
       redirect_to login_url
@@ -17,5 +22,20 @@ class SessionsController < ApplicationController
   def destroy
     reset_session
     redirect_to root_url
+  end
+
+  private
+
+  def schedule_upcoming_events_pull_if_needed(character)
+    # Characters signing for the first time may see their upcoming events
+    # with a significant delay as we use a scheduled job to pull the
+    # events from ESI.
+    #
+    # Pull upcoming events as soon as possible to improve new-user experience.
+    if character.created_at > NEW_SIGNUP_THRESHOLD.ago
+      PullUpcomingEventsJob.
+        set(wait: 3.seconds).
+        perform_later(character.id)
+    end
   end
 end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -1,10 +1,12 @@
 require "rails_helper"
 
 describe SessionsController, type: :controller do
-  before { stub_valid_oauth_hash }
+  before { ActiveJob::Base.queue_adapter = :test }
 
   context "#create" do
     it "redirects to calendar path" do
+      stub_valid_oauth_hash
+
       request.env["omniauth.auth"] = OmniAuth.config.mock_auth[:eve_online_sso]
       request.env["omniauth.origin"] = nil
 
@@ -14,12 +16,34 @@ describe SessionsController, type: :controller do
     end
 
     it "does not redirect to an outside domain" do
+      stub_valid_oauth_hash
+
       request.env["omniauth.auth"] = OmniAuth.config.mock_auth[:eve_online_sso]
       request.env["omniauth.origin"] = "//google.com"
 
       get :create, params: { provider: "eve_online_sso" }
 
       should redirect_to(calendar_url)
+    end
+
+    it "schedules upcoming events pull, when character is new" do
+      stub_valid_oauth_hash(build(:character))
+
+      request.env["omniauth.auth"] = OmniAuth.config.mock_auth[:eve_online_sso]
+      request.env["omniauth.origin"] = nil
+
+      expect { get(:create, params: { provider: "eve_online_sso" }) }.
+        to have_enqueued_job(PullUpcomingEventsJob)
+    end
+
+    it "does not schedule upcoming events pull, when character exists" do
+      stub_valid_oauth_hash(create(:character, created_at: 1.hour.ago))
+
+      request.env["omniauth.auth"] = OmniAuth.config.mock_auth[:eve_online_sso]
+      request.env["omniauth.origin"] = nil
+
+      expect { get(:create, params: { provider: "eve_online_sso" }) }.
+        not_to have_enqueued_job(PullUpcomingEventsJob)
     end
   end
 end


### PR DESCRIPTION
Characters signing for the first time will not see any upcoming events. This is because we pull events in a scheduled background job.

This creates bad experience for newly signed up users as their calendar is empty. Additionally, they may think the tool does not work as advertised.

To improve the experience, upcoming events will be pulled right after new characters sign in.

Closes #167