### PR TITLE
Fix stale void on a refresh token

### DIFF
--- a/app/services/eve/sign_in.rb
+++ b/app/services/eve/sign_in.rb
@@ -23,13 +23,14 @@ module Eve
 
     def update_character_attributes
       character.assign_attributes(
-        uid: character_uid,
         name: character_name,
         owner_hash: character_owner_hash,
-        token: token,
-        token_type: token_type,
         refresh_token: refresh_token,
+        refresh_token_voided_at: nil,
+        token: token,
         token_expires_at: token_expiration_time,
+        token_type: token_type,
+        uid: character_uid,
       )
     end
 

--- a/spec/services/eve/sign_in_spec.rb
+++ b/spec/services/eve/sign_in_spec.rb
@@ -38,6 +38,19 @@ describe Eve::SignIn, "#call" do
         hash["credentials"]["expires_at"].to_i,
       )
     end
+
+    it "removes void, when refresh token voided" do
+      hash = auth_hash
+      existing = create(
+        :character,
+        :with_voided_refresh_token,
+        uid: hash["info"]["character_id"],
+      )
+
+      expect { Eve::SignIn.new(hash).call }.
+        to change { existing.reload.refresh_token_voided_at }.
+        to(nil)
+    end
   end
 
   def auth_hash(options = {})


### PR DESCRIPTION
With each signin, a character receives a new refresh token. Yet, we never remove the void mark on a character's refresh token.

To avoid having a refresh token voided forever, we now remove the void mark each time a character signs in.

Closes #169