### PR TITLE
Don't schedule PullEventDetailsJob deemed to fail

### DIFF
--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -5,6 +5,7 @@ namespace :scheduler do
   task "events:pull": :environment do
     Character.with_active_refresh_token.each_with_index do |character, index|
       delay = (5 + index).minutes
+
       PullUpcomingEventsJob.
         set(wait: delay).
         perform_later(character.id)
@@ -13,9 +14,18 @@ namespace :scheduler do
 
   desc "Schedule pull of event details for all upcoming events"
   task "events:details:pull": :environment do
-    Event.where(details_updated_at: nil).each_with_index do |event, index|
-      delay = 5.minutes + index.seconds
-      PullEventDetailsJob.set(wait: delay).perform_later(event.id)
+    character_ids = Character.with_active_refresh_token.pluck(:id)
+
+    event_ids = Event.
+      where(details_updated_at: nil, character_id: character_ids).
+      pluck(:id)
+
+    event_ids.each_with_index do |event_id, index|
+      delay = (5 + index).minutes
+
+      PullEventDetailsJob.
+        set(wait: delay).
+        perform_later(event_id)
     end
   end
 end


### PR DESCRIPTION
Pulling event details for characters with voided refresh tokens will fail. We don't want to unnecessary send requests to ESI.

From now on, the PullEventDetailsJob will only be scheduled for characters with valid refresh tokens.