### PR TITLE
Log details when scheduling event pull jobs

### DIFF
--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -8,12 +8,12 @@ class Character < ApplicationRecord
   validates :owner_hash, presence: true
   validates :token, presence: true
 
-  def self.with_active_refresh_token
-    where(refresh_token_voided_at: nil)
-  end
-
   def void_refresh_token!
     update!(refresh_token_voided_at: Time.current)
+  end
+
+  def refresh_token_voided?
+    refresh_token_voided_at.present?
   end
 
   def token_expired?

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -1,31 +1,41 @@
-namespace :scheduler do
+namespace :scheduler do # rubocop:disable Metrics/BlockLength
   task pull: "events:pull"
 
   desc "Schedule pull of upcoming events from ESI"
   task "events:pull": :environment do
-    Character.with_active_refresh_token.each_with_index do |character, index|
-      delay = (5 + index).minutes
+    entitled_characters, excluded_characters =
+      Character.all.partition(&:refresh_token_voided?)
 
-      PullUpcomingEventsJob.
-        set(wait: delay).
-        perform_later(character.id)
+    excluded_characters.each do |c|
+      Rails.logger.info "Skip events:pull for character (id = #{c.id})."
+    end
+
+    entitled_characters.each_with_index do |c, index|
+      delay = (5 + index).minutes
+      PullUpcomingEventsJob.set(wait: delay).perform_later(c.id)
     end
   end
 
   desc "Schedule pull of event details for all upcoming events"
   task "events:details:pull": :environment do
-    character_ids = Character.with_active_refresh_token.pluck(:id)
+    entitled_characters, excluded_characters =
+      Character.all.partition(&:refresh_token_voided?)
 
-    event_ids = Event.
-      where(details_updated_at: nil, character_id: character_ids).
-      pluck(:id)
+    excluded_characters.each do |c|
+      Rails.logger.info "Skip events:details:pull for character (id = #{c.id})."
+    end
 
-    event_ids.each_with_index do |event_id, index|
-      delay = (5 + index).minutes
+    character_ids = entitled_characters.pluck(:id)
 
-      PullEventDetailsJob.
-        set(wait: delay).
-        perform_later(event_id)
+    unless character_ids.empty?
+      event_ids = Event.
+        where(details_updated_at: nil, character_id: character_ids).
+        pluck(:id)
+
+      event_ids.each_with_index do |event_id, index|
+        delay = (5 + index).minutes
+        PullEventDetailsJob.set(wait: delay).perform_later(event_id)
+      end
     end
   end
 end

--- a/spec/models/character_spec.rb
+++ b/spec/models/character_spec.rb
@@ -7,27 +7,26 @@ describe Character, type: :model do
     it { should validate_presence_of(:owner_hash) }
   end
 
-  describe ".with_active_refresh_token" do
-    it "excludes characters where refresh token is voided" do
-      create(:character, :with_voided_refresh_token)
-
-      expect(Character.with_active_refresh_token.count).to eq 0
-    end
-
-    it "includes characters where refresh token is not voided" do
-      expected = create(:character)
-
-      expect(Character.with_active_refresh_token.count).to eq 1
-      expect(Character.with_active_refresh_token.last).to eq expected
-    end
-  end
-
   describe "#void_refresh_token!" do
     it "marks the refresh token voided" do
       character = create(:character)
 
       expect { character.void_refresh_token! }.
         to change { character.reload.refresh_token_voided_at }.from(nil)
+    end
+  end
+
+  describe "refresh_token_voided?" do
+    it "is true, when refresh token has been voided" do
+      character = build(:character, refresh_token_voided_at: Time.current)
+
+      expect(character.refresh_token_voided?).to be_truthy
+    end
+
+    it "is false, when refresh token has not been voided" do
+      character = build(:character, refresh_token_voided_at: nil)
+
+      expect(character.refresh_token_voided?).to be_falsey
     end
   end
 


### PR DESCRIPTION
In Skylight, the number of scheduled `PullUpcomingEventsJob` instances is often less than the number of characters with active refresh tokens.

Log the excluded characters.

Closes #232