### PR TITLE
Basic analytics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem "puma", "~> 4.2"
 gem "rack-timeout"
 gem "sass-rails", "~> 6.0"
 gem "sentry-raven"
+gem "staccato"
 gem "turbolinks", "~> 5"
 gem "uglifier", ">= 1.3.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -254,6 +254,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    staccato (0.5.3)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
@@ -311,6 +312,7 @@ DEPENDENCIES
   skylight
   spring
   spring-watcher-listen (~> 2.0.0)
+  staccato
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,11 @@ class ApplicationController < ActionController::Base
   protected
 
   def analytics
-    Analytics.new(current_character)
+    analytics_for(current_character)
+  end
+
+  def analytics_for(character)
+    Analytics.new(character)
   end
 
   def character_settings

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,10 @@ class ApplicationController < ActionController::Base
 
   protected
 
+  def analytics
+    Analytics.new(current_character)
+  end
+
   def character_settings
     Setting.for_character(current_character)
   end

--- a/app/controllers/calendar_feeds_controller.rb
+++ b/app/controllers/calendar_feeds_controller.rb
@@ -10,6 +10,8 @@ class CalendarFeedsController < ApplicationController
   def show
     character = access_token.issuer
 
+    track_access_token_used
+
     events = upcoming_events(character)
 
     render_headers
@@ -27,6 +29,11 @@ class CalendarFeedsController < ApplicationController
   end
 
   private
+
+  def track_access_token_used
+    analytics_for(access_token.grantee).
+      track_access_token_used(access_token, consumer: consumer)
+  end
 
   def upcoming_events(character)
     Event.upcoming_for(character).limit(PAGE_SIZE)
@@ -80,7 +87,10 @@ class CalendarFeedsController < ApplicationController
   end
 
   def add_sentry_tags_context
-    consumer = request.headers["User-Agent"]
     Raven.tags_context(consumer: consumer) if consumer.present?
+  end
+
+  def consumer
+    request.headers["User-Agent"]
   end
 end

--- a/app/controllers/calendar_feeds_controller.rb
+++ b/app/controllers/calendar_feeds_controller.rb
@@ -5,13 +5,15 @@ class CalendarFeedsController < ApplicationController
 
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
 
-  before_action :add_sentry_tags_context
-
   def show
-    character = access_token.issuer
-
     track_access_token_used
 
+    if access_token.revoked? || access_token.expired?
+      record_not_found
+      return
+    end
+
+    character = access_token.issuer
     events = upcoming_events(character)
 
     render_headers
@@ -81,13 +83,8 @@ class CalendarFeedsController < ApplicationController
     response.headers["Date"] = Time.current.utc.rfc2822
   end
 
-  def record_not_found(err)
-    Raven.capture_exception(err, extra: params.to_unsafe_h)
+  def record_not_found
     render plain: "404 Not Found", status: 404
-  end
-
-  def add_sentry_tags_context
-    Raven.tags_context(consumer: consumer) if consumer.present?
   end
 
   def consumer

--- a/app/controllers/calendars_controller.rb
+++ b/app/controllers/calendars_controller.rb
@@ -9,6 +9,8 @@ class CalendarsController < ApplicationController
   def create
     revoke_access_token
 
+    analytics.track_access_token_revoked
+
     redirect_to calendar_url
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -11,6 +11,8 @@ class SessionsController < ApplicationController
     if character.present?
       schedule_upcoming_events_pull_if_needed(character)
 
+      track_character_logged_in(character)
+
       session[:character_id] = character.id
 
       redirect_to calendar_url
@@ -25,6 +27,10 @@ class SessionsController < ApplicationController
   end
 
   private
+
+  def track_character_logged_in(character)
+    Analytics.new(character).track_character_logged_in
+  end
 
   def schedule_upcoming_events_pull_if_needed(character)
     # Characters signing for the first time may see their upcoming events

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -23,6 +23,9 @@ class SessionsController < ApplicationController
 
   def destroy
     reset_session
+
+    analytics.track_character_logged_out
+
     redirect_to root_url
   end
 

--- a/app/jobs/pull_upcoming_events_job.rb
+++ b/app/jobs/pull_upcoming_events_job.rb
@@ -12,6 +12,8 @@ class PullUpcomingEventsJob < ApplicationJob
 
     remote_events = fetch_remote_events
 
+    track_upcoming_events_pulled
+
     Event.transaction do
       # Delete obsolete events
       keep_uids = remote_events.map(&:uid)
@@ -26,6 +28,10 @@ class PullUpcomingEventsJob < ApplicationJob
   private
 
   attr_reader :character_id
+
+  def track_upcoming_events_pulled
+    Analytics.new(character).track_upcoming_events_pulled
+  end
 
   def fetch_remote_events
     character_calendar.events.map do |event|

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -16,7 +16,7 @@ class AccessToken < ApplicationRecord
 
   class << self
     def by_slug!(slug)
-      current.find_by!(token: parse_slug(slug))
+      find_by!(token: parse_slug(slug))
     end
 
     def create_personal!(char)

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -1,4 +1,6 @@
 class Analytics
+  ACCOUNTS_CATEGORY = "Accounts".freeze
+
   class_attribute :backend
 
   def initialize(character, backend: self.backend)
@@ -7,7 +9,7 @@ class Analytics
   end
 
   def track_account_created
-    track("Account created", category: "Accounts", label: character.name)
+    track("Account created", category: ACCOUNTS_CATEGORY, label: character.name)
   end
 
   def track_access_token_revoked
@@ -16,6 +18,10 @@ class Analytics
 
   def track_refresh_token_voided
     track("Refresh token voided", category: "ESI", label: character.name)
+  end
+
+  def track_character_logged_in
+    track("Logged in", category: ACCOUNTS_CATEGORY, label: character.name)
   end
 
   private

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -14,6 +14,10 @@ class Analytics
     track("Access token revoked", category: "Calendars", label: character.name)
   end
 
+  def track_refresh_token_voided
+    track("Refresh token voided", category: "ESI", label: character.name)
+  end
+
   private
 
   attr_reader :character

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -1,0 +1,32 @@
+class Analytics
+  class_attribute :backend
+
+  def initialize(character, backend: self.backend)
+    @backend = backend
+    @character = character
+  end
+
+  def track_account_created
+    track("Account created", category: "Accounts", label: character.name)
+  end
+
+  private
+
+  attr_reader :character
+
+  def track(event, properties = {})
+    backend.event(
+      action: event,
+      user_id: character.id,
+      **default_event_properties.merge(properties),
+    )
+  end
+
+  def default_event_properties
+    {
+      anonymize_ip: true,
+      category: "All",
+      data_source: "server",
+    }
+  end
+end

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -30,9 +30,16 @@ class Analytics
 
   def track_access_token_used(access_token, consumer: nil)
     grantee = access_token.grantee
+    event_action = if access_token.revoked?
+                     "Revoked access token used (#{consumer})"
+                   elsif access_token.expired?
+                     "Expired access token used (#{consumer})"
+                   else
+                     "Access token used (#{consumer})"
+                   end
 
     track(
-      "Access token used (#{consumer})",
+      event_action,
       category: "Calendars",
       label: grantee.name,
       user_id: grantee.id,

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -24,6 +24,10 @@ class Analytics
     track("Logged in", category: ACCOUNTS_CATEGORY, label: character.name)
   end
 
+  def track_character_logged_out
+    track("Logged out", category: ACCOUNTS_CATEGORY, label: character.name)
+  end
+
   private
 
   attr_reader :character

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -28,6 +28,17 @@ class Analytics
     track("Logged out", category: ACCOUNTS_CATEGORY, label: character.name)
   end
 
+  def track_access_token_used(access_token, consumer: nil)
+    grantee = access_token.grantee
+
+    track(
+      "Access token used (#{consumer})",
+      category: "Calendars",
+      label: grantee.name,
+      user_id: grantee.id,
+    )
+  end
+
   private
 
   attr_reader :character

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -46,6 +46,15 @@ class Analytics
     )
   end
 
+  def track_upcoming_events_pulled
+    track(
+      "Upcoming events pulled",
+      category: "Background jobs",
+      label: character.name,
+      non_interactive: true,
+    )
+  end
+
   private
 
   attr_reader :character

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -10,6 +10,10 @@ class Analytics
     track("Account created", category: "Accounts", label: character.name)
   end
 
+  def track_access_token_revoked
+    track("Access token revoked", category: "Calendars", label: character.name)
+  end
+
   private
 
   attr_reader :character

--- a/app/services/eve/renew_access_token.rb
+++ b/app/services/eve/renew_access_token.rb
@@ -22,11 +22,18 @@ module Eve
       #   - 'invalid_request' - token may be malformed
       #   - 'invalid_client', 'invalid_grant', 'unsupported_grant_type',
       #     'invalid_scope'
-      character.void_refresh_token! if /invalid_token/.match?(e.code)
+      if /invalid_token/.match?(e.code)
+        character.void_refresh_token!
+        track_refresh_token_voided
+      end
       raise
     end
 
     private
+
+    def track_refresh_token_voided
+      Analytics.new(character).track_refresh_token_voided
+    end
 
     def should_renew?
       character.token_expired? || forced?

--- a/app/services/eve/sign_in.rb
+++ b/app/services/eve/sign_in.rb
@@ -4,7 +4,6 @@ module Eve
 
     def initialize(auth_hash)
       @auth_hash = auth_hash
-      @new_signup = false
     end
 
     def call

--- a/config/initializers/analytics.rb
+++ b/config/initializers/analytics.rb
@@ -1,0 +1,3 @@
+StaccatoBackend = Staccato.tracker(ENV["ANALYTICS_KEY"] || "", nil, ssl: true)
+
+Analytics.backend = StaccatoBackend

--- a/spec/controllers/calendar_feeds_controller_spec.rb
+++ b/spec/controllers/calendar_feeds_controller_spec.rb
@@ -2,19 +2,25 @@ require "rails_helper"
 require "securerandom"
 
 describe CalendarFeedsController, type: :controller do
-  include StubCurrentCharacterHelper
-
   describe "#show" do
-    it "renders '404 Not Found', when no valid token found" do
-      stub_current_character
+    it "notifies analytics than the access token has been used" do
+      access_token = create(:access_token)
 
+      request.headers["User-Agent"] = "Google calendar"
+
+      get :show, params: { id: access_token.token }
+
+      expect(analytics).
+        to have_tracked("Access token used (Google calendar)")
+    end
+
+    it "renders '404 Not Found', when no valid token found" do
       get :show, params: { id: SecureRandom.uuid }
 
       expect(response.body).to eq("404 Not Found")
     end
 
     it "notifies Sentry, when no valid token found" do
-      stub_current_character
       bad_token = SecureRandom.uuid
       allow(Raven).to receive(:capture_exception)
 

--- a/spec/controllers/calendar_feeds_controller_spec.rb
+++ b/spec/controllers/calendar_feeds_controller_spec.rb
@@ -2,34 +2,39 @@ require "rails_helper"
 require "securerandom"
 
 describe CalendarFeedsController, type: :controller do
+  before { request.headers["User-Agent"] = "Google" }
+
   describe "#show" do
     it "notifies analytics than the access token has been used" do
       access_token = create(:access_token)
 
-      request.headers["User-Agent"] = "Google calendar"
-
       get :show, params: { id: access_token.token }
 
-      expect(analytics).
-        to have_tracked("Access token used (Google calendar)")
+      expect(analytics).to have_tracked("Access token used (Google)")
     end
 
-    it "renders '404 Not Found', when no valid token found" do
+    it "renders '404 Not Found', when token can not be found" do
       get :show, params: { id: SecureRandom.uuid }
 
       expect(response.body).to eq("404 Not Found")
     end
 
-    it "notifies Sentry, when no valid token found" do
-      bad_token = SecureRandom.uuid
-      allow(Raven).to receive(:capture_exception)
+    it "renders '404 Not Found', when token is expired" do
+      access_token = create(:access_token, expires_at: 1.hour.ago)
 
-      get :show, params: { id: bad_token }
+      get :show, params: { id: access_token.token }
 
-      expect(Raven).to have_received(:capture_exception).with(
-        an_instance_of(ActiveRecord::RecordNotFound),
-        extra: controller.params.to_unsafe_h,
-      )
+      expect(response.body).to eq("404 Not Found")
+      expect(analytics).to have_tracked("Expired access token used (Google)")
+    end
+
+    it "renders '404 Not Found', when token is revoked" do
+      access_token = create(:access_token, revoked_at: 1.hour.ago)
+
+      get :show, params: { id: access_token.token }
+
+      expect(response.body).to eq("404 Not Found")
+      expect(analytics).to have_tracked("Revoked access token used (Google)")
     end
   end
 end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 describe SessionsController, type: :controller do
+  include StubCurrentCharacterHelper
+
   before { ActiveJob::Base.queue_adapter = :test }
 
   context "#create" do
@@ -46,6 +48,22 @@ describe SessionsController, type: :controller do
 
       expect { get(:create, params: { provider: "eve_online_sso" }) }.
         not_to have_enqueued_job(PullUpcomingEventsJob)
+    end
+  end
+
+  context "#destroy" do
+    before { stub_current_character }
+
+    it "resets the current session" do
+      expect(controller).to receive(:reset_session)
+
+      get(:destroy)
+    end
+
+    it "logs the current character out" do
+      get(:destroy)
+
+      expect(analytics).to have_tracked("Logged out")
     end
   end
 end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -13,6 +13,8 @@ describe SessionsController, type: :controller do
       get :create, params: { provider: "eve_online_sso" }
 
       should redirect_to(calendar_url)
+
+      expect(analytics).to have_tracked("Logged in")
     end
 
     it "does not redirect to an outside domain" do

--- a/spec/features/subscriber_resets_secret_address_spec.rb
+++ b/spec/features/subscriber_resets_secret_address_spec.rb
@@ -37,6 +37,20 @@ feature "subscriber resets secret address", type: :feature do
     expect(page).to have_text(/not found/i)
   end
 
+  scenario "and analytics receives a revokation event" do
+    create(:access_token, :personal, issuer: current_character)
+
+    visit calendar_path
+    click_reset_button
+
+    expect(analytics).to have_tracked("Access token revoked").
+      with_properties(category: "Calendars", label: current_character.name)
+  end
+
+  def analytics
+    Analytics.backend
+  end
+
   def click_reset_button
     click_on("Reset secret address")
   end

--- a/spec/features/subscriber_resets_secret_address_spec.rb
+++ b/spec/features/subscriber_resets_secret_address_spec.rb
@@ -43,12 +43,7 @@ feature "subscriber resets secret address", type: :feature do
     visit calendar_path
     click_reset_button
 
-    expect(analytics).to have_tracked("Access token revoked").
-      with_properties(category: "Calendars", label: current_character.name)
-  end
-
-  def analytics
-    Analytics.backend
+    expect(analytics).to have_tracked("Access token revoked")
   end
 
   def click_reset_button

--- a/spec/jobs/pull_upcoming_events_job_spec.rb
+++ b/spec/jobs/pull_upcoming_events_job_spec.rb
@@ -43,6 +43,22 @@ describe PullUpcomingEventsJob, type: :job do
       not_to(change { Event.count })
   end
 
+  it "notifies analytics that events have been pulled" do
+    tracker = stub_analytics_tracker
+    create(:event, character: character, starts_at: 1.second.ago)
+    stub_character_calendar(events: [])
+
+    PullUpcomingEventsJob.perform_now(character.id)
+
+    expect(tracker).to have_received(:track_upcoming_events_pulled)
+  end
+
+  def stub_analytics_tracker
+    stub_analytics.tap do |tracker|
+      allow(tracker).to receive(:track_upcoming_events_pulled)
+    end
+  end
+
   def character
     @character ||= create(:character)
   end

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -59,17 +59,23 @@ describe AccessToken, type: :model do
   end
 
   describe ".by_slug!" do
-    it "returns found token" do
-      access_token = create(:access_token)
+    it "finds the token, when personal" do
+      access_token = create(:access_token, :personal)
 
-      found = AccessToken.by_slug!(access_token.token)
+      found = AccessToken.by_slug!(access_token.slug)
 
       expect(found).to eq(access_token)
-      expect(found).not_to be_revoked
-      expect(found).not_to be_expired
     end
 
-    context "when not found" do
+    it "finds the token, when shared" do
+      access_token = create(:access_token)
+
+      found = AccessToken.by_slug!(access_token.slug)
+
+      expect(found).to eq(access_token)
+    end
+
+    context "when token does not exist" do
       it "raises an error" do
         expect do
           AccessToken.by_slug!("non-existing")

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -25,6 +25,8 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 
 RSpec.configure do |config|
+  config.before(:each) { Analytics.backend = FakeStaccato.new }
+
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -29,6 +29,8 @@ RSpec.configure do |config|
 
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
+
+  config.include AnalyticsHelper
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -33,4 +33,14 @@ describe Analytics do
         with_properties(label: character.name, category: "ESI")
     end
   end
+
+  describe "#track_character_logged_in" do
+    it "it tracks that a character logged in" do
+      analytics_instance.track_character_logged_in
+
+      expect(analytics).to have_tracked("Logged in").
+        for_character(character).
+        with_properties(label: character.name, category: "Accounts")
+    end
+  end
 end

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -14,4 +14,14 @@ describe Analytics do
         with_properties(label: character.name, category: "Accounts")
     end
   end
+
+  describe "#track_access_token_revoked" do
+    it "tracks that an access token has been revoked" do
+      analytics_instance.track_access_token_revoked
+
+      expect(analytics).to have_tracked("Access token revoked").
+        for_character(character).
+        with_properties(label: character.name, category: "Calendars")
+    end
+  end
 end

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -104,4 +104,18 @@ describe Analytics do
       end
     end
   end
+
+  describe "#track_upcoming_events_pulled" do
+    it "tracks that upcoming events have been pulled" do
+      analytics_instance.track_upcoming_events_pulled
+
+      expect(analytics).to have_tracked("Upcoming events pulled").
+        for_character(character).
+        with_properties(
+          category: "Background jobs",
+          label: character.name,
+          non_interactive: true,
+        )
+    end
+  end
 end

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe Analytics do
+  let(:analytics_instance) { Analytics.new(character) } # rubocop:disable Metrics/LineLength
+  let(:character) { build_stubbed(:character) }
+  let(:analytics) { analytics_instance.backend }
+
+  describe "#track_account_created" do
+    it "tracks that a new account was created" do
+      analytics_instance.track_account_created
+
+      expect(analytics).to have_tracked("Account created").
+        for_character(character).
+        with_properties(label: character.name, category: "Accounts")
+    end
+  end
+end

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 describe Analytics do
   let(:analytics_instance) { Analytics.new(character) } # rubocop:disable Metrics/LineLength
   let(:character) { build_stubbed(:character) }
-  let(:analytics) { analytics_instance.backend }
 
   describe "#track_account_created" do
     it "tracks that a new account was created" do

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -43,4 +43,14 @@ describe Analytics do
         with_properties(label: character.name, category: "Accounts")
     end
   end
+
+  describe "#track_character_logged_out" do
+    it "it tracks that a character logged out" do
+      analytics_instance.track_character_logged_out
+
+      expect(analytics).to have_tracked("Logged out").
+        for_character(character).
+        with_properties(label: character.name, category: "Accounts")
+    end
+  end
 end

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -23,4 +23,14 @@ describe Analytics do
         with_properties(label: character.name, category: "Calendars")
     end
   end
+
+  describe "#track_refresh_token_voided" do
+    it "tracks that ESI‘s refresh token has been voided" do
+      analytics_instance.track_refresh_token_voided
+
+      expect(analytics).to have_tracked("Refresh token voided").
+        for_character(character).
+        with_properties(label: character.name, category: "ESI")
+    end
+  end
 end

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -67,5 +67,41 @@ describe Analytics do
         for_character(access_token.grantee).
         with_properties(category: "Calendars", label: access_token.grantee.name)
     end
+
+    context "when expired" do
+      it "tracks that an expired access token has been used" do
+        access_token = build(:access_token, expires_at: 1.hour.ago)
+
+        analytics_instance.track_access_token_used(
+          access_token,
+          consumer: "Google",
+        )
+
+        expect(analytics).to have_tracked("Expired access token used (Google)").
+          for_character(access_token.grantee).
+          with_properties(
+            category: "Calendars",
+            label: access_token.grantee.name,
+          )
+      end
+    end
+
+    context "when revoked" do
+      it "tracks that a revoked access token has been used" do
+        access_token = build(:access_token, revoked_at: 1.hour.ago)
+
+        analytics_instance.track_access_token_used(
+          access_token,
+          consumer: "Google",
+        )
+
+        expect(analytics).to have_tracked("Revoked access token used (Google)").
+          for_character(access_token.grantee).
+          with_properties(
+            category: "Calendars",
+            label: access_token.grantee.name,
+          )
+      end
+    end
   end
 end

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -53,4 +53,19 @@ describe Analytics do
         with_properties(label: character.name, category: "Accounts")
     end
   end
+
+  describe "#track_access_token_used" do
+    it "tracks that an access token has been used" do
+      access_token = build(:access_token)
+
+      analytics_instance.track_access_token_used(
+        access_token,
+        consumer: "Google Calendar",
+      )
+
+      expect(analytics).to have_tracked("Access token used (Google Calendar)").
+        for_character(access_token.grantee).
+        with_properties(category: "Calendars", label: access_token.grantee.name)
+    end
+  end
 end

--- a/spec/services/eve/renew_access_token_spec.rb
+++ b/spec/services/eve/renew_access_token_spec.rb
@@ -32,6 +32,8 @@ describe Eve::RenewAccessToken do
         to change { character.reload.token }.
         from("old").
         to("new")
+
+      expect(analytics).not_to have_tracked("Refresh token voided")
     end
 
     it "updates character's access token expiration time" do
@@ -96,6 +98,7 @@ describe Eve::RenewAccessToken do
         expect { Eve::RenewAccessToken.new(character, force: true).call }.
           to raise_error(OAuth2::Error) do
           expect(character).to have_received(:void_refresh_token!)
+          expect(analytics).to have_tracked("Refresh token voided")
         end
       end
     end

--- a/spec/services/eve/sign_in_spec.rb
+++ b/spec/services/eve/sign_in_spec.rb
@@ -91,9 +91,8 @@ describe Eve::SignIn, "#call" do
   end
 
   def stub_analytics_tracker
-    instance_double(Analytics).tap do |tracker|
+    stub_analytics.tap do |tracker|
       allow(tracker).to receive(:track_account_created)
-      allow(Analytics).to receive(:new).and_return(tracker)
     end
   end
 

--- a/spec/support/analytics_helper.rb
+++ b/spec/support/analytics_helper.rb
@@ -1,0 +1,11 @@
+module AnalyticsHelper
+  def analytics
+    Analytics.backend
+  end
+
+  def stub_analytics
+    instance_double(Analytics).tap do |analytics|
+      allow(Analytics).to receive(:new).and_return(analytics)
+    end
+  end
+end

--- a/spec/support/fake_staccato.rb
+++ b/spec/support/fake_staccato.rb
@@ -1,0 +1,47 @@
+class FakeStaccato
+  class EventsList
+    def initialize(events)
+      @events = events
+    end
+
+    def <<(event)
+      events << event
+    end
+
+    def events_for(user)
+      self.class.new(
+        events.select { |e| e[:user_id] == user.id },
+      )
+    end
+
+    def named(event_name)
+      self.class.new(
+        events.select { |e| e[:action] == event_name },
+      )
+    end
+
+    def has_properties?(options)
+      events.any? do |event|
+        options.all? { |key, value| event[key] == value }
+      end
+    end
+
+    private
+
+    attr_reader :events
+  end
+
+  attr_reader :tracked_events
+
+  def initialize
+    @tracked_events = EventsList.new([])
+  end
+
+  def event(options)
+    tracked_events << options
+  end
+
+  def tracked_events_for(user)
+    tracked_events.events_for(user)
+  end
+end

--- a/spec/support/matchers/have_tracked.rb
+++ b/spec/support/matchers/have_tracked.rb
@@ -1,0 +1,20 @@
+RSpec::Matchers.define :have_tracked do |event_name|
+  match do |analytics_backend|
+    @event_name = event_name
+    @analytics_backend = analytics_backend
+
+    events =
+      if @character.present?
+        analytics_backend.tracked_events_for(@character)
+      else
+        analytics_backend.tracked_events
+      end
+
+    events.
+      named(@event_name).
+      has_properties?(@properties || {})
+  end
+
+  chain(:for_character) { |character| @character = character }
+  chain(:with_properties) { |properties| @properties = properties }
+end


### PR DESCRIPTION
Closes #248 

This PR adds analytics support via Google Analytics.

To avoid unwanted tracking of our users, we‘ll use a server-side implementation of Google‘s Analytics Measurement Protocol. This way we have full control over what data is sent.

We track the following events
* An account has been created
* A character logs in
* A character logs out
* An access token has been revoked
* An access token has been used
* An expired access token has been used
* A revoked access token has been used
* An ESI refresh token has been voided
* Upcoming events have been pulled from ESI