### PR TITLE
Don‘t post to analytics during development

### DIFF
--- a/config/initializers/analytics.rb
+++ b/config/initializers/analytics.rb
@@ -1,4 +1,18 @@
 ActiveSupport.on_load(:analytics) do
   # `self` refers to Analytics class. See `app/services/analytics.rb`
-  self.backend = Staccato.tracker(ENV["ANALYTICS_KEY"] || "", nil, ssl: true)
+  self.backend = Staccato.tracker(ENV["ANALYTICS_KEY"] || "", nil, ssl: true) do |c| # rubocop:disable Metrics/LineLength
+    if c.id.blank?
+      require "staccato/adapter/logger"
+
+      formatter = lambda { |params|
+        "Analytics: " << params.map { |k, v| [k, v].join("=") }.join(" ")
+      }
+
+      c.add_adapter Staccato::Adapter::Logger.new(
+        Staccato.ga_collection_uri,
+        Rails.logger,
+        formatter,
+      )
+    end
+  end
 end


### PR DESCRIPTION
We‘ll post to the analytics service only when ENV["ANALYTICS_KEY"] is set. Otherwise analytics events will be logged via the Rails.logger