### PR TITLE
Switch to release version of faker gem

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ default_job: &default_job
     # Restore Cached Dependencies
     - type: cache-restore
       name: Restore bundle cache
-      key:
+      keys:
         - ruby-265-v1-{{ checksum "Gemfile.lock" }}
         - ruby-265-v1-
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,9 @@ default_job: &default_job
     # Restore Cached Dependencies
     - type: cache-restore
       name: Restore bundle cache
-      key: evecal-{{ checksum "Gemfile.lock" }}
+      key:
+        - ruby-265-v1-{{ checksum "Gemfile.lock" }}
+        - ruby-265-v1-
 
     # Bundle install dependencies
     - run: bundle install --path vendor/bundle
@@ -15,7 +17,7 @@ default_job: &default_job
     # Cache Dependencies
     - type: cache-save
       name: Store bundle cache
-      key: evecal-{{ checksum "Gemfile.lock" }}
+      key: ruby-265-v1-{{ checksum "Gemfile.lock" }}
       paths:
         - vendor/bundle
 

--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ group :development, :test do
   gem "byebug", platforms: %i[mri mingw x64_mingw]
   gem "dotenv-rails"
   gem "factory_bot_rails"
-  gem "faker", git: "https://github.com/stympy/faker.git", branch: "master"
+  gem "faker"
   gem "rspec-rails", ">= 4.0.0.beta3"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/stympy/faker.git
-  revision: c95ff7827f508c96293f380f387a681f502934a5
-  branch: master
-  specs:
-    faker (2.8.0)
-      i18n (>= 1.6, < 1.8)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -115,6 +107,8 @@ GEM
     factory_bot_rails (5.1.1)
       factory_bot (~> 5.1.0)
       railties (>= 4.2.0)
+    faker (2.8.0)
+      i18n (>= 1.6, < 1.8)
     faraday (0.17.0)
       multipart-post (>= 1.2, < 3)
     ffi (1.11.1)
@@ -312,7 +306,7 @@ DEPENDENCIES
   dotenv-rails
   eve_online
   factory_bot_rails
-  faker!
+  faker
   icalendar
   jbuilder (~> 2.9)
   listen (>= 3.0.5, < 3.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -289,7 +289,7 @@ GEM
     websocket-extensions (0.1.4)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.2.1)
+    zeitwerk (2.2.2)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
This commit should reduce amount of spam from dependabot about updating faker gem.

Bonus: fix caching on Circle CI. From now, circle ci cache installed gems by key `ruby-265-v1-{{ checksum "Gemfile.lock" }}` and restore by `ruby-265-v1-{{ checksum "Gemfile.lock" }}` and (if not found) by `ruby-265-v1-`. Small updates of gem will not require rebuild all gems.

Why so strange format for key? Ok, `ruby-` -- means that this is ruby bundler gems cache. `265` -- ruby version. I recommend to add this and increment we ruby update. And `-v1` is cache version (for case when something go wrong and we need to reset cache).

Also, I update zeitwerk gem to check that cache restoring works as I expect. Yep, it works. :)

