### PR TITLE
Fix oauth_client_options

### DIFF
--- a/app/services/eve/renew_access_token.rb
+++ b/app/services/eve/renew_access_token.rb
@@ -63,7 +63,7 @@ module Eve
     end
 
     def oauth_client_options
-      OmniAuth::Strategies::EveOnlineSso.default_options["client_options"].deep_symbolize_keys
+      OmniAuth::Strategies::EveOnlineSso.default_options["client_options"].to_hash.symbolize_keys
     end
   end
 end


### PR DESCRIPTION
`OmniAuth::Strategies::EveOnlineSso.default_options["client_options"]`returns subclass of `Hash` and breaks. Create new hash by call `.to_hash` and `.symbolize_keys`.
