### PR TITLE
Replace `byebug` with `break`

### DIFF
--- a/.idea/eventical.iml
+++ b/.idea/eventical.iml
@@ -46,6 +46,7 @@
     <orderEntry type="library" scope="PROVIDED" name="bindex (v0.8.1, asdf: 3.0.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="bootsnap (v1.9.1, asdf: 3.0.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="bootstrap (v4.6.0, asdf: 3.0.1) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="break (v0.30.0, asdf: 3.0.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="builder (v3.2.4, asdf: 3.0.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="bundler (v2.2.16, asdf: 3.0.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="byebug (v11.1.3, asdf: 3.0.1) [gem]" level="application" />
@@ -99,32 +100,31 @@
     <orderEntry type="library" scope="PROVIDED" name="matrix (v0.4.2, asdf: 3.0.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="method_source (v1.0.0, asdf: 3.0.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="mini_mime (v1.1.2, asdf: 3.0.1) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="mini_portile2 (v2.7.1, asdf: 3.0.1) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="mini_portile2 (v2.8.0, asdf: 3.0.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="minitest (v5.15.0, asdf: 3.0.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="msgpack (v1.4.2, asdf: 3.0.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="multi_json (v1.15.0, asdf: 3.0.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="multi_xml (v0.6.0, asdf: 3.0.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="multipart-post (v2.1.1, asdf: 3.0.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="nio4r (v2.5.8, asdf: 3.0.1) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="nokogiri (v1.13.1, asdf: 3.0.1) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="nokogiri (v1.13.3, asdf: 3.0.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="oauth2 (v1.4.7, asdf: 3.0.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="omniauth (v2.0.4, asdf: 3.0.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="omniauth-eve_online-sso (v0.5.0, asdf: 3.0.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="omniauth-oauth2 (v1.7.2, asdf: 3.0.1) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="omniauth-rails_csrf_protection (v1.0.0, asdf: 3.0.1) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="omniauth-rails_csrf_protection (v1.0.1, asdf: 3.0.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="parallel (v1.20.1, asdf: 3.0.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="parser (v3.0.1.1, asdf: 3.0.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="pg (v1.2.3, asdf: 3.0.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="popper_js (v1.16.0, asdf: 3.0.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="poro-rails (v0.2.1, asdf: 3.0.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="pry (v0.13.1, asdf: 3.0.1) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="pry-byebug (v3.9.0, asdf: 3.0.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="pry-rails (v0.3.9, asdf: 3.0.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="public_suffix (v4.0.6, asdf: 3.0.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="puma (v5.6.2, asdf: 3.0.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="racc (v1.6.0, asdf: 3.0.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rack (v2.2.3, asdf: 3.0.1) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rack-protection (v2.1.0, asdf: 3.0.1) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rack-protection (v2.2.0, asdf: 3.0.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rack-proxy (v0.7.0, asdf: 3.0.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rack-test (v1.1.0, asdf: 3.0.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rack-timeout (v0.6.0, asdf: 3.0.1) [gem]" level="application" />

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,6 @@ gem "omniauth", "~> 2.0"
 gem "omniauth-eve_online-sso"
 gem "omniauth-rails_csrf_protection", "~> 1.0"
 gem "pg"
-gem "pry-byebug"
 gem "pry-rails"
 gem "puma", "~> 5.6"
 gem "rack-timeout"
@@ -31,9 +30,7 @@ gem "uglifier", ">= 1.3.0"
 gem "webpacker"
 
 group :development, :test do
-  # Call 'byebug' anywhere in the code to stop execution and get
-  # a debugger console
-  gem "byebug", platforms: %i[mri mingw x64_mingw]
+  gem "break"
   gem "climate_control"
   gem "dotenv-rails"
   gem "factory_bot_rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,8 +74,8 @@ GEM
       autoprefixer-rails (>= 9.1.0)
       popper_js (>= 1.14.3, < 2)
       sassc-rails (>= 2.0.0)
+    break (0.30.0)
     builder (3.2.4)
-    byebug (11.1.3)
     capybara (3.36.0)
       addressable
       matrix
@@ -211,9 +211,6 @@ GEM
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.9.0)
-      byebug (~> 11.0)
-      pry (~> 0.13.0)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (4.0.6)
@@ -377,7 +374,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.1.0)
   bootstrap (~> 4.6.0)
-  byebug
+  break
   capybara (>= 2.15)
   chromedriver-helper
   climate_control
@@ -396,7 +393,6 @@ DEPENDENCIES
   omniauth-rails_csrf_protection (~> 1.0)
   pg
   poro-rails
-  pry-byebug
   pry-rails
   puma (~> 5.6)
   rack-timeout


### PR DESCRIPTION
Byebug does not play well with Zeitwerk. This commit switches to Break.

Reference:
- https://github.com/fxn/zeitwerk#byebug
- https://github.com/gsamokovarov/break