### PR TITLE
Use `delete_all` when replacing events

### DIFF
--- a/app/models/character_events/replacement.rb
+++ b/app/models/character_events/replacement.rb
@@ -17,7 +17,7 @@ class CharacterEvents::Replacement
   attr_reader :upcoming_events
 
   def replace_events
-    removed_events.destroy_all
+    removed_events.delete_all
 
     upcoming_events.map do |event|
       Event.synchronize(event)


### PR DESCRIPTION
Currently, there are no callbacks/dependent actions defined. Hence, we can benefit from replacing `destroy_all` with `delete_all`.